### PR TITLE
Remove all RCTEventEmitter events from iOS native code

### DIFF
--- a/ios/RNDocViewer.h
+++ b/ios/RNDocViewer.h
@@ -1,12 +1,11 @@
 #import <Foundation/Foundation.h>
 #import <QuickLook/QuickLook.h>
-#import <React/RCTEventEmitter.h>
 #import <React/RCTBridgeModule.h>
 #import <React/RCTLog.h>
 
 
 
-@interface RNDocViewer : RCTEventEmitter <RCTBridgeModule, QLPreviewControllerDelegate, QLPreviewControllerDataSource, QLPreviewItem, UIAlertViewDelegate>
+@interface RNDocViewer : NSObject <RCTBridgeModule, QLPreviewControllerDelegate, QLPreviewControllerDataSource, QLPreviewItem, UIAlertViewDelegate>
 @property (strong, nonatomic) NSURL* fileUrl;
 @property (strong, nonatomic) NSString* optionalFileName;
 @property (readonly) NSURL* previewItemURL;

--- a/ios/RNDocViewer.m
+++ b/ios/RNDocViewer.m
@@ -18,10 +18,10 @@ CGFloat prog;
 
 RCT_EXPORT_MODULE()
 
-- (NSArray<NSString *> *)supportedEvents
-{
-    return @[@"RNDownloaderProgress", @"DoneButtonEvent", @"CancelEvent", @"OKEvent"];
-}
+// - (NSArray<NSString *> *)supportedEvents
+// {
+//     return @[@"RNDownloaderProgress", @"DoneButtonEvent", @"CancelEvent", @"OKEvent"];
+// }
 
 - (dispatch_queue_t)methodQueue
 {
@@ -326,7 +326,7 @@ RCT_EXPORT_METHOD(playMovie:(NSString *)file callback:(RCTResponseSenderBlock)ca
 
 
 - (void)DoneButtonClicked {
-    [self sendEventWithName:@"DoneButtonEvent" body:@{ @"close": @true}];
+    // [self sendEventWithName:@"DoneButtonEvent" body:@{ @"close": @true}];
 }
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error {
@@ -345,9 +345,9 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
         prog = (float)totalBytesWritten/totalBytesExpectedToWrite;
         //NSLog(@"downloaded %d%%", (int)(100.0*prog));
         NSNumber *progress = @([@(totalBytesWritten) floatValue]/[@(totalBytesExpectedToWrite) floatValue] * 100.0);
-        [self sendEventWithName:@"RNDownloaderProgress" body:@{ @"totalBytesWritten": @(totalBytesWritten),
-                                                                @"totalBytesExpectedToWrite": @(totalBytesExpectedToWrite),
-                                                                @"progress": progress }];
+        // [self sendEventWithName:@"RNDownloaderProgress" body:@{ @"totalBytesWritten": @(totalBytesWritten),
+        //                                                         @"totalBytesExpectedToWrite": @(totalBytesExpectedToWrite),
+        //                                                         @"progress": progress }];
 
     });
 }
@@ -370,11 +370,11 @@ RCT_EXPORT_METHOD(showAlert:(NSString *)msg) {
     
     if (buttonIndex == 0) {
         // Sent event tap on Cancel
-        [self sendEventWithName:@"CancelEvent" body:@"Tap on Cancel"];
+        // [self sendEventWithName:@"CancelEvent" body:@"Tap on Cancel"];
         
     } else if (buttonIndex == 1) {
         // Sent event tap on Ok
-        [self sendEventWithName:@"OKEvent" body:@"Tap on OK"];
+        // [self sendEventWithName:@"OKEvent" body:@"Tap on OK"];
     }
 }
 


### PR DESCRIPTION
**For some reason,** this library was causing an issue with FirebasePerformance after it was [upgraded in this PR](https://github.com/CompanyCam/companycam-mobile/pull/2176)

Here's a screenshot of the issue:

![Screen Shot 2021-03-26 at 1 45 55 PM](https://user-images.githubusercontent.com/15896334/112694946-36ee1580-8e51-11eb-82d1-655e1651d2ab.png)

The shortest route to resolving this was **remove all events** emitted by this library. We did actually listen to one of these events, but for reasons that were no longer necessary -- so it was safe to remove [(more info in this PR)](https://github.com/CompanyCam/companycam-mobile/pull/2193)

## Solution

Commented out all events emitted. 

Opted for _commenting_ in the case we want to (for some reason) re-invoke them. (Though I suppose with a git history we could just delete!)
