### PR TITLE
Fix for compile configuration removed in Gradle 7

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,6 +31,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }
   


### PR DESCRIPTION
Pretty straighforward swap - otherwise, RN .70 won't compile.
https://docs.gradle.org/7.0/userguide/upgrading_version_6.html#sec:configuration_removal